### PR TITLE
Feature/python 3 11

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9.x, 3.10.x]
+        python-version: [3.9.x, 3.10.x, 3.11.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9.x, 3.10.x]
+        python-version: [3.9.x, 3.10.x, 3.11.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/type-hints.yml
+++ b/.github/workflows/type-hints.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9.x, 3.10.x]
+        python-version: [3.9.x, 3.10.x, 3.11.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9.x, 3.10.x]
+        python-version: [3.9.x, 3.10.x, 3.11.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GH actions does not seem to consider release candidates as proper versions with just "3.11.x". Run this again when there is a proper release